### PR TITLE
Handle the results.detail  is None in Mooncake context

### DIFF
--- a/src/spring-cloud/azext_spring_cloud/custom.py
+++ b/src/spring-cloud/azext_spring_cloud/custom.py
@@ -706,7 +706,7 @@ def validate_config_server_settings(client, resource_group, name, git_property):
         raise CLIError("{0}. You may raise a support ticket if needed by the following link: https://docs.microsoft.com/azure/spring-cloud/spring-cloud-faq?pivots=programming-language-java#how-can-i-provide-feedback-and-report-issues".format(err))
 
     if not result.is_valid:
-        for item in result.details:
+        for item in result.details or []:
             if not item.name:
                 logger.error("Default repository with URI \"%s\" meets error:", item.uri)
             else:


### PR DESCRIPTION
There is no different when the Config server validate reponse success. But when the validation failed, in public cloud the response should be 
```diff
- {"isValid":false,"details":[{"name":"","uri":"https://github.com/Azure-Samples/piggymetr","messages":["URI is inaccessible. Check if URI and label are correct."]}]}
``` 
while the response in mooncake is 
```diff
+ {"isValid":false,"configServerSettingsErrorRecords":[{"name":"","uri":"https://github.com/Azure-Samples/piggymetr","message":["https://github.com/Azure-Samples/piggymetr with label 'master' is not accessible"]}]}
```

The for loop will throw a NoneType exception in mooncake context, because there is no details field.

With the default value set, the output in mooncake is:

```
(CLITest) >az spring-cloud config-server git set -n billingtest -g yuwzho --uri https://github.com/Azure-Samples/piggymetr 
[1/2] Validating config server settings
ValidationError: Config Server settings contain error.
```

In public cloud should be no difference:

```
(CLITest) >az spring-cloud config-server git set -n test-hub-cac -g test-hub-region --uri https://github.com/Azure-Samples/piggymetr
[1/2] Validating config server settings
Default repository with URI "https://github.com/Azure-Samples/piggymetr" meets error:
URI is inaccessible. Check if URI and label are correct.
ValidationError: Config Server settings contain error.
```